### PR TITLE
Update common.php

### DIFF
--- a/language/nl/acp/common.php
+++ b/language/nl/acp/common.php
@@ -75,6 +75,8 @@ $lang = array_merge($lang, array(
 	'ACP_CAT_USERS'				=> 'Gebruikers',
 	'ACP_CLIENT_COMMUNICATION'	=> 'Cliënt communicatie',
 	'ACP_COOKIE_SETTINGS'		=> 'Cookieinstellingen',
+	'ACP_CONTACT'				=> 'Contact formulier',
+	'ACP_CONTACT_SETTINGS'		=> 'Instellingen contact formulier',	
 	'ACP_CRITICAL_LOGS'			=> 'Foutenlog',
 	'ACP_CUSTOM_PROFILE_FIELDS'	=> 'Aangepaste profielvelden',
 


### PR DESCRIPTION
Ontbrekende taalvariabelen contact pagina toegevoegd:

```
'ACP_CONTACT'               => 'Contact page',
'ACP_CONTACT_SETTINGS'      => 'Contact page settings',
```

Ik heb het vertaald als contact formulier omdat dit mijns inziens beter klinkt
