### PR TITLE
Update common.php

### DIFF
--- a/language/nl/common.php
+++ b/language/nl/common.php
@@ -170,6 +170,7 @@ $lang = array_merge($lang, array(
 	'CONNECTION_FAILED'		=> 'Verbinding verbroken.',
 	'CONNECTION_SUCCESS'	=> 'Succesvol verbonden!',
 	'CONTACT'				=> 'Contact',
+	'CONTACT_US'			=> 'Contact',
 	'CONTACT_USER'			=> 'Contact %s',
 	'COOKIES_DELETED'		=> 'Alle forumcookies succesvol verwijderd.',
 	'CURRENT_TIME'			=> 'Het is momenteel %s',


### PR DESCRIPTION
Toegevoegd: 

'CONTACT_US'            => 'Contact us',

Vertaald als: Contact

Had ook "Contacteer ons" kunnen zijn, maar dat lijkt mij te lang en "contact" lijkt mij een gangbare manier
