### PR TITLE
Update posting.php

### DIFF
--- a/language/nl/posting.php
+++ b/language/nl/posting.php
@@ -227,7 +227,7 @@ $lang = array_merge($lang, array(
 	),
 	'QUOTE_NO_NESTING'			=> 'Je mag geen citaten in elkaar plaatsen.',
 
-	'REMOTE_UPLOAD_TIMEOUT'         => 'The specified file could not be uploaded because the request timed out.',
+	'REMOTE_UPLOAD_TIMEOUT'         => 'Het gespecificeerde bestand kon niet worden geüpload omdat de aanvraag is verlopen.',
 	'SAVE'						=> 'Opslaan',
 	'SAVE_DATE'					=> 'Opgeslagen op',
 	'SAVE_DRAFT'				=> 'Bewaar concept',


### PR DESCRIPTION
Ik heb deze taal variabel alvast toegevoegd, maar hij is nog niet vertaald. Ik kan geen passende vertaling bedenken voor deze zin:

'REMOTE_UPLOAD_TIMEOUT' => 'The specified file could not be uploaded because the request timed out.',

Het bestand kon niet worden geüpload....

Request timed out, is dat vergelijkbaar met de ingestelde tijdslimiet voor bestanden uploaden of een server time out of dergelijke? Heb alvast een pull request ingediend, omdat ik hem toch nog kan aanpassen. Comitten heet dan geloof ik... 
