### PR TITLE
Remove trailing space behind {EMAIL_SIG}

### DIFF
--- a/language/nl/email/forum_notify.txt
+++ b/language/nl/email/forum_notify.txt
@@ -18,4 +18,4 @@ Als je niet langer meer geabonneerd wil zijn op dit forum, klik dan op de "Uitsc
 
 {U_STOP_WATCHING_FORUM}
 
-{EMAIL_SIG} 
+{EMAIL_SIG}


### PR DESCRIPTION
Gives an error during language package validation.

btw: The same in you 3.2.9 upload, althought the 3.2.x branch does not have this trailing space, your branch "329_rc" has it. 