### PR TITLE
Fix "ingedied" typo in Password Reset mail

### DIFF
--- a/language/nl/email/user_forgot_password.txt
+++ b/language/nl/email/user_forgot_password.txt
@@ -2,7 +2,7 @@ Subject: Nieuw wachtwoord activeren
 
 Hallo {USERNAME},
 
-Je ontvangt dit bericht, omdat je (of iemand die zich voordoet als jou) een verzoek heeft ingedied om je wachtwoord te herstellen op {SITENAME}
+Je ontvangt dit bericht, omdat je (of iemand die zich voordoet als jou) een verzoek heeft ingediend om je wachtwoord te herstellen op {SITENAME}
 
 Klik op de volgende link om je wachtwoord te resetten:
 


### PR DESCRIPTION
Should be "ingediend"