### PR TITLE
phpBB 3.3.8 support and bug fixes in PM Folder translations

### DIFF
--- a/language/nl/common.php
+++ b/language/nl/common.php
@@ -432,6 +432,7 @@ $lang = array_merge($lang, array(
 	'MESSAGE'				=> 'Bericht',
 	'MESSAGES'				=> 'Berichten',
 	'MESSAGES_COUNT'		=> array(
+		0	=> 'onbeperkte berichten',
 		1	=> '%d bericht',
 		2	=> '%d berichten',
 	),
@@ -606,7 +607,7 @@ $lang = array_merge($lang, array(
 	'POSTS_UNAPPROVED_FORUM'=> 'Tenminste één bericht in dit forum is nog niet goedgekeurd.',
 	'POST_BY_AUTHOR'		=> 'door',
 	'POST_BY_FOE'			=> '<strong>%1$s</strong>, die momenteel op je negeerlijst staat, heeft dit bericht geschreven.',
-	'POST_DISPLAY'			=> '%1$sDit bericht weergeven%2$s.',
+	'POST_DISPLAY'			=> 'Dit bericht weergeven.',
 	'POST_DAY'				=> '%.2f berichten per dag',
 	'POST_DELETED_ACTION'	=> 'Verwijderd bericht:',
 	'POST_DELETED'			=> 'Dit bericht is verwijderd.',

--- a/language/nl/ucp.php
+++ b/language/nl/ucp.php
@@ -229,8 +229,8 @@ $lang = array_merge($lang, array(
 	'FOES_UPDATED'				=> 'Je vijandenlijst is succesvol bijgewerkt.',
 	'FOLDER_ADDED'				=> 'Map succesvol toegevoegd.',
 	'FOLDER_MESSAGE_STATUS'		=> array(
-		1	=> '%2$d van %1$s bericht opgeslagen',
-		2	=> '%2$d van %1$s berichten opgeslagen',
+		1	=> '%2$d van %1$s opgeslagen',
+		2	=> '%2$d van %1$s opgeslagen',
 	),
 	'FOLDER_NAME_EMPTY'			=> 'Je moet een naam invoeren voor deze map.',
 	'FOLDER_NAME_EXIST'			=> 'Map <strong>%s</strong> bestaat al.',

--- a/language/nl/ucp.php
+++ b/language/nl/ucp.php
@@ -238,8 +238,8 @@ $lang = array_merge($lang, array(
 	'FOLDER_RENAMED'			=> 'Map succesvol hernoemd.',
 	'FOLDER_REMOVED'			=> 'Map succesvol verwijderd.',
 	'FOLDER_STATUS_MSG'			=> array(
-		1	=> '%2$d van de %1$s opgeslagen',
-		2	=> '%2$d van de %1$s opgeslagen',
+		1	=> 'Map is %3$d%% vol (%2$d van %1$s opgeslagen)',
+		2	=> 'Map is %3$d%% vol (%2$d van %1$s opgeslagen)',
 	),
 	'FORWARD_PM'				=> 'PB doorsturen',
 	'FORCE_PASSWORD_EXPLAIN'	=> 'Voordat je door kunt gaan met het bezoeken van het forum, moet je je wachtwoord veranderen.',


### PR DESCRIPTION
- Added phpBB 3.3.8 support based on [English Diff](https://gist.github.com/marc1706/fcd270047d67a6b730159404645362af)
- Removed duplicate "bericht/berichten" in PM settings as seen here:
![PM_settings_typo](https://user-images.githubusercontent.com/318762/181576136-d8b1fea8-36e5-4440-9a9b-00fb93d74dd2.png)
- Restored Private Message full percentage, is now correctly translated from English. Will look like this:
![PM_full_percentage](https://user-images.githubusercontent.com/318762/181575294-0505e303-863b-4689-8885-1ac48e2f347b.png)
 